### PR TITLE
Set version via a tag class attribute

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "buildozer",
-    version = "6.4.0",
+    version = "0.0.0",
     bazel_compatibility = [">=6.2.0"],
 )
 
@@ -13,6 +13,7 @@ buildozer_binary.buildozer(
         "linux-arm64": "6559558fded658c8fa7432a9d011f7c4dcbac6b738feae73d2d5c352e5f605fa",
         "windows-amd64": "e7f05bf847f7c3689dd28926460ce6e1097ae97380ac8e6ae7147b7b706ba19b",
     },
+    version = "6.4.0",
 )
 use_repo(buildozer_binary, "buildozer_binary")
 

--- a/private/buildozer_binary.bzl
+++ b/private/buildozer_binary.bzl
@@ -61,6 +61,7 @@ _buildozer_binary_repo = repository_rule(
 _buildozer_tag_class = tag_class(
     attrs = {
         "sha256": attr.string_dict(),
+        "version": attr.string(),
     },
 )
 
@@ -71,7 +72,7 @@ def _buildozer_binary_impl(module_ctx):
             if mod.name != "buildozer":
                 fail("The buildozer tag is currently reserved for internal use only")
             buildozer_attrs["sha256"] = tag.sha256
-            buildozer_attrs["version"] = mod.version
+            buildozer_attrs["version"] = tag.version
 
     if not buildozer_attrs:
         fail("No buildozer tag found")

--- a/release/update.sh
+++ b/release/update.sh
@@ -13,7 +13,7 @@ cd $BUILD_WORKSPACE_DIRECTORY
 buildozer_cmds_file=$(mktemp)
 trap 'rm -f -- "$buildozer_cmds_file"' EXIT
 
-echo "set version $version|//MODULE.bazel:buildozer" > "$buildozer_cmds_file"
+echo "set version $version|//MODULE.bazel:%buildozer_binary.buildozer" > "$buildozer_cmds_file"
 
 sha256_dict=""
 declare -a os_archs=("darwin-amd64" "darwin-arm64" "linux-amd64" "linux-arm64" "windows-amd64")


### PR DESCRIPTION
Otherwise releases can fail while tests pass when the module version isn't updated correctly or uses a format that differs from the buildozer version scheme.