### PR TITLE
Improve Windows support and make the top-level buildozer target public

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -17,7 +17,8 @@ bcr_test_module:
         # Workaround for https://github.com/bazelbuild/bazel/issues/3268
         - echo bazel-bcr/>> .bazelignore
       run_targets:
-        - //:run_buildozer
+        - //:buildozer_alias  # Run the alias with no args.
+        - //:run_buildozer  # Will modify a test target.
       build_targets:
         - //...
       test_targets:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,15 +1,8 @@
-sh_binary(
+# A buildozer binary that will run in the root repository's workspace directory.
+alias(
     name = "buildozer",
-    srcs = ["buildozer.sh"],
-    data = [
-        "@buildozer_binary//:buildozer.exe",
-    ],
-    env = {
-        "BUILDOZER_RLOCATIONPATH": "$(rlocationpath @buildozer_binary//:buildozer.exe)",
-    },
-    deps = [
-        "@bazel_tools//tools/bash/runfiles",
-    ],
+    actual = "@buildozer_binary//:source_buildozer",
+    visibility = ["//visibility:public"],
 )
 
 exports_files(["buildozer.bzl"])

--- a/private/BUILD.bazel
+++ b/private/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["buildozer.template.sh", "buildozer.template.bat"])

--- a/private/buildozer.template.bat
+++ b/private/buildozer.template.bat
@@ -2,14 +2,33 @@
 SETLOCAL ENABLEEXTENSIONS
 SETLOCAL ENABLEDELAYEDEXPANSION
 
-set MF=MANIFEST
+set MF=%RUNFILES_MANIFEST_FILE:/=\\%
 set PATH=%SYSTEMROOT%\system32
 
-REM Lookup the buildozer binary in the runfiles manifest.
-for /F "tokens=2* usebackq" %%i in (`findstr.exe /l /c:"%%BUILDOZER_RLOCATIONPATH%% " "%MF%"`) do (
-  set BUILDOZER=%%i
-  set BUILDOZER=!BUILDOZER:/=\!
+REM If not given a RUNFILES_MANIFEST_FILE env var, this should be the top level executable.
+REM Try the MANIFEST in the current directory. When runfiles are disabled, the current directory
+REM is set to the (mostly empty) runfiles directory.
+if not exist %MF% (
+    set MF=MANIFEST
 )
+
+REM If runfiles are enabled, the current directory will be set to the main repository under
+REM the runfiles directory.
+if not exist %MF% (
+    set MF=..\MANIFEST
+)
+
+REM Only look up the binary in the runfiles manifest, since this batch file does not read
+REM the repo mapping. Reading the repo mapping would be required in order to locate a runfile
+REM in the runfiles directory by path alone.
+if exist %MF% (
+  REM Lookup the buildozer binary in the runfiles manifest.
+  for /F "tokens=2* usebackq" %%i in (`findstr.exe /l /c:"%%BUILDOZER_RLOCATIONPATH%% " "%MF%"`) do (
+    set BUILDOZER=%%i
+    set BUILDOZER=!BUILDOZER:/=\!
+  )
+)
+
 if "!BUILDOZER!" equ "" (
   echo>&2 ERROR: %%BUILDOZER_RLOCATIONPATH%% not found in runfiles.
   exit /b 1

--- a/private/buildozer.template.bat
+++ b/private/buildozer.template.bat
@@ -1,0 +1,23 @@
+@echo off
+SETLOCAL ENABLEEXTENSIONS
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+set MF=MANIFEST
+set PATH=%SYSTEMROOT%\system32
+
+REM Lookup the buildozer binary in the runfiles manifest.
+for /F "tokens=2* usebackq" %%i in (`findstr.exe /l /c:"%%BUILDOZER_RLOCATIONPATH%% " "%MF%"`) do (
+  set BUILDOZER=%%i
+  set BUILDOZER=!BUILDOZER:/=\!
+)
+if "!BUILDOZER!" equ "" (
+  echo>&2 ERROR: %%BUILDOZER_RLOCATIONPATH%% not found in runfiles.
+  exit /b 1
+)
+
+REM Run the newly found full path to the executable within the build's workspace.
+cd %BUILD_WORKSPACE_DIRECTORY%
+!BUILDOZER! %*
+if %ERRORLEVEL% neq 0 (
+  exit /b %ERRORLEVEL%
+)

--- a/private/buildozer.template.sh
+++ b/private/buildozer.template.sh
@@ -16,10 +16,9 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v3 ---
 
-BUILDOZER_RLOCATIONPATH=%%BUILDOZER_RLOCATIONPATH%%
-buildozer_path=$(rlocation "$BUILDOZER_RLOCATIONPATH")
+buildozer_path=$(rlocation "%%BUILDOZER_RLOCATIONPATH%%")
 if [[ ! -f "$buildozer_path" ]]; then
-    echo "buildozer.exe not found at runfiles path $BUILDOZER_RLOCATIONPATH and resolved path $buildozer_path."
+    echo "buildozer.exe not found at runfiles path %%BUILDOZER_RLOCATIONPATH%% and resolved path $buildozer_path."
     exit 1
 fi
 

--- a/private/buildozer.template.sh
+++ b/private/buildozer.template.sh
@@ -5,10 +5,6 @@ if [[ -z "${BUILD_WORKING_DIRECTORY+x}" ]]; then
     exit 1
 fi
 
-# Disable MSYS path conversion, which can otherwise mess up Bazel labels.
-export MSYS2_ARG_CONV_EXCL=*
-export MSYS_NO_PATHCONV=1
-
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
 set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
@@ -20,7 +16,8 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v3 ---
 
-buildozer_path=$(rlocation $BUILDOZER_RLOCATIONPATH)
+BUILDOZER_RLOCATIONPATH=%%BUILDOZER_RLOCATIONPATH%%
+buildozer_path=$(rlocation "$BUILDOZER_RLOCATIONPATH")
 if [[ ! -f "$buildozer_path" ]]; then
     echo "buildozer.exe not found at runfiles path $BUILDOZER_RLOCATIONPATH and resolved path $buildozer_path."
     exit 1

--- a/private/buildozer_binary.bzl
+++ b/private/buildozer_binary.bzl
@@ -1,6 +1,58 @@
 load("@bazel_features//:features.bzl", "bazel_features")
 
-visibility("//")
+def _source_buildozer_impl(ctx):
+    executable = ctx.actions.declare_file(ctx.label.name + (".bat" if ctx.attr.is_windows else ".sh"))
+
+    ctx.actions.expand_template(
+        template = ctx.file._windows_template if ctx.attr.is_windows else ctx.file._linux_template,
+        output = executable,
+        is_executable = True,
+        substitutions = {
+            "%%BUILDOZER_RLOCATIONPATH%%": ctx.file.buildozer_binary.short_path.lstrip("../"),
+        }
+    )
+    files = [ctx.file.buildozer_binary]
+    if not ctx.attr.is_windows:
+        files.append(ctx.file._bash_runfiles)
+
+    return [
+        DefaultInfo(
+            files = depset([executable]),
+            executable = executable,
+            runfiles = ctx.runfiles(files),
+        )
+    ]
+
+source_buildozer = rule(
+    doc = "An executable buildozer binary that changes directory into a workspace before running.",
+    implementation = _source_buildozer_impl,
+    attrs = {
+        "buildozer_binary": attr.label(
+            doc = "Buildozer binary to run. Must come from an external repository.",
+            allow_single_file = True,
+            executable = True,
+            cfg = "target",
+            mandatory = True,
+        ),
+        "is_windows": attr.bool(
+            doc = "Whether the buildozer binary will be running on Windows.",
+            mandatory = True,
+        ),
+        "_bash_runfiles": attr.label(
+            allow_single_file = True,
+            default = Label("@bazel_tools//tools/bash/runfiles"),
+        ),
+        "_linux_template": attr.label(
+            allow_single_file = [".sh"],
+            default = Label("//private:buildozer.template.sh"),
+        ),
+        "_windows_template": attr.label(
+            allow_single_file = [".bat"],
+            default = Label("//private:buildozer.template.bat"),
+        )
+    },
+    executable = True,
+)
 
 def _get_buildozer_os(rctx_os):
     name = rctx_os.name
@@ -26,7 +78,6 @@ def _get_buildozer_arch(rctx_os):
 
 def _buildozer_binary_repo_impl(repository_ctx):
     repository_ctx.file("WORKSPACE")
-    repository_ctx.file("BUILD.bazel", """exports_files(["buildozer.exe"])""")
 
     os = _get_buildozer_os(repository_ctx.os)
     arch = _get_buildozer_arch(repository_ctx.os)
@@ -34,6 +85,18 @@ def _buildozer_binary_repo_impl(repository_ctx):
     sha256 = repository_ctx.attr.sha256.get(os_arch)
     if not sha256:
         fail("No match for '{os_arch}' in sha256".format(os_arch = os_arch))
+
+    repository_ctx.file("BUILD.bazel", """\
+load("@buildozer//private:buildozer_binary.bzl", "source_buildozer")
+exports_files(["buildozer.exe"])
+
+source_buildozer(
+    name = "source_buildozer",
+    buildozer_binary = "buildozer.exe",
+    is_windows = {is_windows},
+    visibility = ["//visibility:public"],
+)
+""".format(is_windows = os == "windows"))
 
     repository_ctx.download(
         url = [

--- a/tests/bcr/BUILD.bazel
+++ b/tests/bcr/BUILD.bazel
@@ -5,3 +5,8 @@ sh_binary(
     },
     srcs = ["run_buildozer.sh"],
 )
+
+alias(
+    name = "buildozer_alias",
+    actual = "@buildozer",
+)


### PR DESCRIPTION
We should support
```
alias(
    name = "buildozer",
    actual = "@buildozer//:buildozer",
    tags = ["manual"],
)
```

I think this makes more sense than bringing buildozer_binary into scope in my module