### PR TITLE
Fail `update.sh` process if one `buildozer` artifact is missing

### DIFF
--- a/release/update.sh
+++ b/release/update.sh
@@ -26,7 +26,7 @@ do
     fi
     url="https://github.com/bazelbuild/buildtools/releases/download/v${version}/buildozer-${os_arch}${extension}"
     echo "Computing checksum for $url..."
-    sha256=$(curl -sL $url | sha256sum | cut -d' ' -f1)
+    sha256=$(curl -sfL $url | sha256sum | cut -d' ' -f1) || { echo "Error: Failed to download $url" >&2; exit 1; }
     sha256_dict="${sha256_dict:+${sha256_dict} }${os_arch}:${sha256}"
 done
 


### PR DESCRIPTION
It was incorrectly processing the `curl` failure output creating a hash, giving the impression the code will work at runtime. It happened to me when adding `windows-arm64` support, which is missing on `8.2.1`. Now it fails rightfully like that:
```
$ ~/Developer/buildozer bazel run //release:update 8.2.1
INFO: Analyzed target //release:update (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //release:update up-to-date:
  bazel-bin/release/update
INFO: Elapsed time: 0.060s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/release/update <args omitted>
Computing checksum for https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildozer-darwin-amd64...
Computing checksum for https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildozer-darwin-arm64...
Computing checksum for https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildozer-linux-amd64...
Computing checksum for https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildozer-linux-arm64...
Computing checksum for https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildozer-linux-s390x...
Computing checksum for https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildozer-windows-amd64.exe...
Computing checksum for https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildozer-windows-arm64.exe...
Error: Failed to download https://github.com/bazelbuild/buildtools/releases/download/v8.2.1/buildozer-windows-arm64.exe
```